### PR TITLE
bluechi_0.6.0.bb: Fix variable assignment

### DIFF
--- a/meta-bluechi/recipes-core/bluechi/bluechi_0.6.0.bb
+++ b/meta-bluechi/recipes-core/bluechi/bluechi_0.6.0.bb
@@ -36,4 +36,4 @@ do_install:append() {
     install -D ${WORKDIR}/bluechi-agent.conf ${D}/etc/bluechi/agent.conf.d/00-default.conf
 }
 
-REQUESTED_DISTRO_FEATURES = "systemd"
+REQUIRED_DISTRO_FEATURES += "systemd"


### PR DESCRIPTION
According to Yocto Reference Manual, there is no such variable as "REQUESTED_DISTRO_FEATURES". The variable is called "REQUIRED_DISTRO_FEATURES". 
Due to the fact, that some other DISTRO_FEATURES might already be required due to inheritance of classes, I changed the variable assignment to "+=" in order to append instead of overwrite the variable.