### PR TITLE
add qemuarm target

### DIFF
--- a/bluechi-machine/kas/base.yml
+++ b/bluechi-machine/kas/base.yml
@@ -1,6 +1,6 @@
 header:
-  version: 12
-machine: qemux86-64
+  version: 14
+machine: generic
 local_conf_header:
   default: | 
     INHERIT += "extrausers"

--- a/bluechi-machine/kas/qemuarm.yml
+++ b/bluechi-machine/kas/qemuarm.yml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - bluechi-machine/kas/base.yml
+machine: qemuarm

--- a/bluechi-machine/kas/qemux86_64.yaml
+++ b/bluechi-machine/kas/qemux86_64.yaml
@@ -1,0 +1,5 @@
+header:
+  version: 14
+  includes:
+    - bluechi-machine/kas/base.yml
+machine: qemux86-64


### PR DESCRIPTION
## Changes

* Move existing machine file to `base.yml`;
* Create a target file for each architecture (qemux86-64 and qemuarm), each file including the base configuration;
* Builds can be issued as `kas build kas/$target.yml`.