### PR TITLE
README fix for styhead

### DIFF
--- a/meta-bluechi/README.md
+++ b/meta-bluechi/README.md
@@ -8,10 +8,10 @@ Dependencies
 ============
 
   URI: git://git.yoctoproject.org/meta-virtualization
-  branch: kirkstone
+  branch: styhead
 
   URI: git://git.openembedded.org/openembedded-core
-  branch: kirkstone
+  branch: styhead
 
 Patches
 =======


### PR DESCRIPTION
Changes readme instructions to point to "styhead" instead of "kirkstone".